### PR TITLE
Create a Dockerfile for deploying the symbol server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/target
+.DS_Store
+/symbols
+/winsymbols

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# First, we need to build and cache our dependencies so it doesn't have to
+# rebuild them every time we build this Dockerfile.
+# See https://github.com/LukeMathWalker/cargo-chef for more information.
+FROM lukemathwalker/cargo-chef:latest-rust-slim-bullseye as chef
+WORKDIR /app
+
+# Let's start with preparing the dependencies.
+FROM chef as planner
+# Copy the project files into the planner.
+COPY . .
+# Compute a lock-like file for our project
+RUN cargo chef prepare  --recipe-path recipe.json
+
+# Continue with building our project.
+FROM chef as builder
+
+# Copy the recipe.json file from the planner stage.
+COPY --from=planner /app/recipe.json recipe.json
+
+# Build our project dependencies, not our application!
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Up to this point, if our dependency tree stays the same,
+# all layers should be cached.
+COPY . .
+
+# Build our project.
+RUN cargo build --release --bin reliost
+
+# This is the final image that will be used in production.
+FROM debian:bullseye-slim AS runtime
+WORKDIR /app
+ENV PORT=8080
+# Set the app environment to production.
+ENV APP_ENVIRONMENT="production"
+
+# Install OpenSSL - it is dynamically linked by some of our dependencies
+# Install ca-certificates - it is needed to verify TLS certificates
+# when establishing HTTPS connections.
+RUN apt-get update -y \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  # Clean up
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  # Clean the downloaded lists so that they don't increase the layer size.
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy the compiled binary from the builder image.
+COPY --from=builder /app/target/release/reliost reliost
+
+# Copy the configuration files as they are needed for the runtime.
+COPY configuration configuration
+
+# This is the default port as configured above.
+EXPOSE $PORT
+
+# Run the application.
+ENTRYPOINT ["./reliost"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,38 @@
+# Docker
+
+In this document, you can find some basic commands like creating and handling a docker container for this project.
+
+## Basic commands
+
+### Build the docker image
+
+All the instructions for building a docker image is located in the [Dockerfile](../Dockerfile).
+
+To be able to build the image, run:
+
+```bash
+docker build -t reliost:dev .
+```
+
+Additionally, `--rm` can be passed to remove the intermediate containers after the build. Also, `--pull` can be passed to update the base images that are being used inside the Dockerfile.
+
+The new created image will have the `reliost:dev` tag.
+
+### Run the docker image in a container
+
+The built image can be run with the following command:
+
+```bash
+docker run -t -i --rm -p 8080:8080 --name reliost reliost:dev
+```
+
+Here is a quick explanation of the command line parameters:
+
+- `-t` allocates a pseudo-tty, while `-i` makes the container interactive. These
+  two parameters makes it possible to interact with the container. Especially
+  Ctrl-C can gracefully stop the container.
+- `--rm` removes the container when it stops.
+- `-p 8080:8080` makes the container listen on port 8080, and binds it to the
+  inner port 8080 which is the default port configured while building the
+  container.
+- `--name` gives a name to this container so that it's easier to reference in commands.


### PR DESCRIPTION
This PR adds a Dockerfile so we can build a docker image for this API.
I will add more documentation soon, but to be able to try it locally, run:

```bash
docker build -t reliost:dev .
# or if you want to remove intermediate containers after the build:
docker build -t reliost:dev . --rm

# then to run:
docker run -t -i --rm -p 8080:8080 --name reliost reliost:dev
```