### PR TITLE
Remove unneeded symbol server lookup

### DIFF
--- a/configuration/base.toml
+++ b/configuration/base.toml
@@ -1,7 +1,6 @@
 # Servers from which we can download Breakpad .sym files
 [symbols.breakpad]
 servers = [
-  "https://symbols.mozilla.org",
   "https://symbols.mozilla.org/try"
 ]
 cache_dir = "./symbols/"


### PR DESCRIPTION
/try covers both the regular and try symbols, so you only need to use this url.

This removes an additional symbols server lookup from the list.