### PR TITLE
Remove unneeded symbol server

### DIFF
--- a/configuration/base.toml
+++ b/configuration/base.toml
@@ -9,7 +9,6 @@ symindex_dir = "./symbols/"
 # Servers from which we can download Windows .pdb, .exe and .dll files
 [symbols.windows]
 servers = [
-  "https://symbols.mozilla.org",
   "https://symbols.mozilla.org/try",
   "https://msdl.microsoft.com/download/symbols"
 ]


### PR DESCRIPTION
/try covers both the regular and try symbols, so you only need to use this url.

This removes an additional symbols server lookup from the windows servers list.