### PR TITLE
Remove the unnecessary health_check endpoint

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -7,10 +7,6 @@ pub async fn greet() -> impl Responder {
     "Hello world!".to_string()
 }
 
-pub async fn health_check() -> impl Responder {
-    HttpResponse::Ok()
-}
-
 pub async fn symbolicate_v5(
     contents: web::Bytes,
     symbol_manager: web::Data<Arc<SymbolManager>>,

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,7 +1,7 @@
 use std::{net::TcpListener, sync::Arc};
 
 use crate::configuration::Settings;
-use crate::routes::{asm_v1, greet, health_check, heartbeat, lbheartbeat, symbolicate_v5, version};
+use crate::routes::{asm_v1, greet, heartbeat, lbheartbeat, symbolicate_v5, version};
 use crate::symbol_manager::create_symbol_manager;
 use actix_cors::Cors;
 use actix_web::{dev::Server, web, App, HttpServer};
@@ -18,7 +18,6 @@ pub fn run(listener: TcpListener, settings: Settings) -> Result<Server, std::io:
             .wrap(cors)
             .wrap(TracingLogger::default())
             .route("/", web::get().to(greet))
-            .route("/health_check", web::get().to(health_check))
             .route("/symbolicate/v5", web::post().to(symbolicate_v5))
             .route("/asm/v1", web::post().to(asm_v1))
             // Dockerflow requirements. See:

--- a/tests/integration_tests/dockerflow.rs
+++ b/tests/integration_tests/dockerflow.rs
@@ -3,12 +3,26 @@ use std::net::TcpListener;
 use reliost::{configuration::ServerSettings, configuration::Settings};
 
 #[tokio::test]
-async fn health_check_works() {
+async fn heartbeat_works() {
     let address = spawn_app();
 
     let client = reqwest::Client::new();
     let response = client
-        .get(&format!("http://{address}/health_check"))
+        .get(&format!("http://{address}/__heartbeat__"))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+    assert!(response.status().is_success());
+    assert_eq!(response.content_length(), Some(0));
+}
+
+#[tokio::test]
+async fn lbheartbeat_works() {
+    let address = spawn_app();
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(&format!("http://{address}/__lbheartbeat__"))
         .send()
         .await
         .expect("Failed to execute request.");

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -1,1 +1,1 @@
-mod health_check;
+mod dockerflow;


### PR DESCRIPTION
We have `__heartbeat__` and `__lbheartbeat__` for health check and load balancer health check. We don't need this additional endpoint anymore.