### PR TITLE
Build the docker image on pull requests as well

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,14 @@
-name: Docker Publish
+name: Docker
 
 on:
   push:
     branches:
-      - "production"
+      - main
+      - production
+  pull_request:
+    branches:
+      - main
+      - production
 
 jobs:
   build:
@@ -12,9 +17,29 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build the Docker image
         run: |
-          docker build . --file Dockerfile --tag reliost:$(date +%s) \
+          docker build . --file Dockerfile --tag reliost:dev \
             --build-arg github_build_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             --build-arg github_run_id=$GITHUB_RUN_ID
-      # This will be done later.
-      # - name: Publish the Docker image
-      #   run:
+      - name: Archive Docker image
+        run: docker save -o image.tar reliost:dev
+      # This makes it possible to load this image from subsequent jobs.
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docker-image
+          path: ./image.tar
+  # TODO: Publish it to either Docker Hub or Google Artifact Registry.
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/production' }}
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: docker-image
+          path: ./image.tar
+      - name: Display structure of downloaded files
+        run: ls -al
+      - name: Load archived Docker image
+        run: docker load -i ./image.tar
+      - name: Publish Docker Image to Docker Hub
+        run: echo This will push images in the future.


### PR DESCRIPTION
That was recommended in the Dockerflow. And it seems like a good idea to make sure that we don't break the Dockerfile or docker images.