### PR TITLE
Accept environment variables that override config settings in files

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -88,6 +88,15 @@ pub fn get_configuration() -> Result<Settings, ConfigError> {
         .add_source(config::File::from(
             configuration_directory.join(environment_filename),
         ))
+        // Add in settings from environment variables (with a prefix of RELIOST
+        // and '_' as separator)
+        // E.g. `RELIOST_SERVER_PORT=5001 would set `Settings.server.port`.
+        // Note that env vars take precedence over other config files.
+        .add_source(
+            config::Environment::with_prefix("RELIOST")
+                .prefix_separator("_")
+                .separator("_"),
+        )
         .build()?;
     settings.try_deserialize::<Settings>()
 }


### PR DESCRIPTION
This allows us to pass app settings as environment variables. This is needed when we need to pass sensitive information or when users need to override some of the settings quicly without changing the config files.