### PR TITLE
Allow caching CORS headers.

### DIFF
--- a/src/startup.rs
+++ b/src/startup.rs
@@ -21,7 +21,8 @@ pub fn run(
         let cors = Cors::default()
             .allow_any_origin()
             .allowed_methods(vec!["GET", "POST", "OPTION"])
-            .allow_any_header();
+            .allow_any_header()
+            .max_age(86400);
         App::new()
             .wrap(cors)
             .wrap(TracingLogger::default())


### PR DESCRIPTION
See https://httptoolkit.com/blog/cache-your-cors/ for background. Without this change, the browser was making one OPTIONS request per symbolication request.