### PR TITLE
Set up Docker image publishing to mozcloud/GAR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # required for Workload Identity Federation to GCP
+    steps:
+      - uses: actions/checkout@v5
+
+      # mozilla/deploy-actions/docker-build tags the image per MozCloud
+      # conventions -- 10-char short SHA on branch pushes (matches the
+      # tenant's stage image_regex) and the raw tag name on tag pushes
+      # (matches the tenant's prod image_regex when tags are CalVer,
+      # e.g. v2026.07.23).
+      - name: Build image
+        id: build
+        uses: mozilla/deploy-actions/docker-build@v6.7.0
+        with:
+          image_name: reliost
+          gar_name: reliost-prod
+          project_id: moz-fx-reliost-prod
+          # Passed to build.rs so version.json embeds the correct build URL.
+          docker_build_args: |
+            github_server_url=${{ github.server_url }}
+            github_repository=${{ github.repository }}
+            github_run_id=${{ github.run_id }}
+
+      # Only push on branch/tag pushes; PR runs stop at build for validation.
+      # mozilla/deploy-actions/docker-push derives the WIF provider path and
+      # service account by convention from the project number and project id --
+      # SA is artifact-writer@moz-fx-reliost-prod.iam.gserviceaccount.com.
+      - name: Push image
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: mozilla/deploy-actions/docker-push@v6.7.0
+        with:
+          image_tags: ${{ steps.build.outputs.image_tags }}
+          project_id: moz-fx-reliost-prod
+          workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,39 @@
 ARG userid=10001
 ARG groupid=10001
 
-FROM debian:bookworm-slim
+# Build stage: uses cargo-chef so that dependency compilation is cached across
+# builds -- only the "cook" layer needs to rerun when the recipe changes.
+# See https://github.com/LukeMathWalker/cargo-chef for more information.
+FROM lukemathwalker/cargo-chef:latest-rust-1-trixie AS chef
+WORKDIR /app
 
-# VERSION must be passed as a build arg, e.g. --build-arg VERSION=0.1.0
-ARG VERSION
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+# Read by build.rs to construct the build URL embedded in version.json.
+ARG github_server_url
+ARG github_repository
+ARG github_run_id
+ENV GITHUB_SERVER_URL=${github_server_url}
+ENV GITHUB_REPOSITORY=${github_repository}
+ENV GITHUB_RUN_ID=${github_run_id}
+RUN cargo build --release --bin reliost
+
+# Runtime stage.
+FROM debian:trixie-slim AS runtime
+
 ARG userid
 ARG groupid
 
+# openssl: dynamically linked by some dependencies.
+# ca-certificates: needed for HTTPS to upstream symbol servers.
 RUN apt-get update -y \
-  && apt-get install -y --no-install-recommends curl ca-certificates xz-utils openssl \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
   && apt-get autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
@@ -19,16 +43,15 @@ RUN set -x \
   && useradd -g app --uid $userid --shell /usr/sbin/nologin --create-home --home-dir /app app
 
 WORKDIR /app
-
-RUN curl -LsSf \
-    "https://github.com/mstange/reliost/releases/download/v${VERSION}/reliost-v${VERSION}-x86_64-unknown-linux-gnu.tar.xz" \
-  | tar -xJ --strip-components=1
-
+COPY --from=builder /app/target/release/reliost reliost
 COPY configuration configuration
 
-ENV PORT=8080
 ENV APP_ENVIRONMENT="production"
-EXPOSE $PORT
+# mozcloud tenant declares application_ports: [8000]. This overrides the
+# port from configuration/production.toml, which is 8080 for the hetzner
+# deploy (nginx proxies to :8080 there).
+ENV RELIOST_SERVER_PORT=8000
+EXPOSE 8000
 
 USER app
 ENTRYPOINT ["./reliost"]

--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,0 @@
-# Tell the App Engine to use the Dockerfile in the current directory.
-runtime: custom
-env: flex
-
-# Let's use the manual scaling with 1 instance for now.
-# We need to remove this once we really want to deploy for production.
-manual_scaling:
-  instances: 1


### PR DESCRIPTION
This restores the Docker build to work properly, and sets up publishing to GAR on tags.

In commit 0776ca4edeb85d989f3b6b74b4da4e622912c5bc I had removed the docker CI workflow and changed the docker build to download the cargo release artifact - that was rather misguided because it meant that the docker build would no longer reflect your local changes.

This commit reverts most of that.

The port stuff is now a bit complicated; rather than coming from the toml file always, we use the `RELIOST_SERVER_PORT` env var as an override, and the docker build sets that to 8000. This matches the
mozcloud tenant's `application_ports` declaration.
(But maybe there's another env var that Dockerflow tells us to use? Need to double check.)

The new Docker CI workflow uses mozilla/deploy-actions/docker-build  and docker-push composite actions. We build on PRs, and we push to GAR on main + version tags.