### PR TITLE
Make the number of Actix workers configurable.

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -20,6 +20,7 @@ pub struct SelfProfilesSettings {
 pub struct ServerSettings {
     pub host: String,
     pub port: u16,
+    pub workers: Option<usize>,
 }
 
 #[derive(Deserialize)]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -18,11 +18,12 @@ pub fn run(
     listener: TcpListener,
     settings: Settings,
 ) -> Result<(Server, Option<QuotaManager>), std::io::Error> {
+    let workers = settings.server.workers;
     let self_profiles_dir: web::Data<Option<PathBuf>> =
         web::Data::new(settings.self_profiles.as_ref().map(|s| s.dir.clone()));
     let (symbol_manager, quota_manager) = create_symbol_manager_and_quota_manager(settings);
     let app_data = web::Data::new(Arc::new(symbol_manager));
-    let server = HttpServer::new(move || {
+    let mut server = HttpServer::new(move || {
         let cors = Cors::default()
             .allow_any_origin()
             .allowed_methods(vec!["GET", "POST", "OPTION"])
@@ -48,8 +49,10 @@ pub fn run(
             .app_data(app_data.clone())
             .app_data(self_profiles_dir.clone())
             .app_data(web::PayloadConfig::new(100 * 1000 * 1000)) // 100 MB
-    })
-    .listen(listener)?
-    .run();
+    });
+    if let Some(workers) = workers {
+        server = server.workers(workers);
+    }
+    let server = server.listen(listener)?.run();
     Ok((server, quota_manager))
 }

--- a/tests/integration_tests/main.rs
+++ b/tests/integration_tests/main.rs
@@ -15,6 +15,7 @@ fn spawn_app() -> (String, JoinHandle<Result<(), std::io::Error>>) {
         server: ServerSettings {
             host: host.to_string(),
             port,
+            workers: None,
         },
         symbols: None,
         quota: None,


### PR DESCRIPTION
Currently it's hard to predict how many Actix workers Reliost will end up using when running in Kubernetes (see https://doc.rust-lang.org/nightly/std/thread/fn.available_parallelism.html, which is used as the default number of workers by actix-web). This PR keeps the current default while making it possible to explicitly configure the worker count.